### PR TITLE
Update dev tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,16 @@
 A webapp to coordinate aid and care in the Twin Cities.
 
 ## Run Locally
-Globally install https://www.npmjs.com/package/http-server and run `http-server` (defaulting to port 8080).
+
+To run a development server that will auto-reload on save, run this command from the project directory:
+
+`
+npm run dev
+`
+
+A server will run on http://localhost:8080
+
+Alternately, you can run `npx http-server`, or install https://www.npmjs.com/package/http-server and run `http-server` (defaulting to port 8080).
 
 ## Maki Icons
 https://labs.mapbox.com/maki-icons/

--- a/package.json
+++ b/package.json
@@ -1,0 +1,20 @@
+{
+  "name": "twin-cities-aid-distribution-locations",
+  "version": "0.0.1",
+  "description": "A webapp to coordinate aid and care in the Twin Cities.",
+  "main": "index.html",
+  "scripts": {
+    "dev": "npx servor --reload",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/jdalt/twin-cities-aid-distribution-locations.git"
+  },
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/jdalt/twin-cities-aid-distribution-locations/issues"
+  },
+  "homepage": "https://github.com/jdalt/twin-cities-aid-distribution-locations#readme"
+}


### PR DESCRIPTION
This adds option to use [`servor`](https://github.com/lukejacksonn/servor) for a dev server (alternative to `http-server`) which will also auto-reload when files are saved.

Run `npm run dev` and a server will start at http://localhost:8080

(The old `http-server` method will still work.)