### PR TITLE
Fix Loading Issue Caused by Invalid "status"

### DIFF
--- a/script.js
+++ b/script.js
@@ -171,7 +171,7 @@ const onMapLoad = async () => {
         mostRecentlyUpdatedAt: item.gsx$mostrecentlyupdated.$t
       }
       const location = _.pickBy(rawLocation, val => val != '')
-      const status = getStatus(item.gsx$color.$t)
+      const status = getStatus(item.gsx$color.$t) || {}
 
       // transform location properties into HTML
       const propertyTransforms = {


### PR DESCRIPTION
Invalid `status` causes js error that crashes entries after m. Quick dirty fix to get all entries showing again. Root cause this later and figure out how to make things sufficiently robust.
