### PR TITLE
Update legend styles

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -21,8 +21,7 @@ body { margin: 0; padding: 0; }
   padding: 10px;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   line-height: 18px;
-  height: 140px;
-  margin-bottom: 40px;
+  margin-bottom: 25px;
   width: 250px;
   overflow: hidden;
 }
@@ -41,6 +40,7 @@ body { margin: 0; padding: 0; }
   width: 350px;
   padding: 1em;
   margin-left: 0;
+
 }
 .card {
   padding: .25em;
@@ -76,23 +76,28 @@ body { margin: 0; padding: 0; }
 ul.filters {
   list-style: none;
   padding: 0;
-  
+
 }
 
 ul.filters li {
   padding: .25em 0;
 }
 @media only screen and (max-width: 720px) {
+  .map-overlay {
+    background: rgba(255, 255, 255, 1 );
+  }
   #legend.map-overlay {
     margin: 0;
     left: 0;
-    width: 100%;
-    padding: 5px;
+    width: calc(100% - 20px);
+    padding: 10px;
     font-size: 10px;
     height: 55px;
+    z-index: 3;
   }
   #legend.map-overlay div {
     display: inline-block;
+    margin-right: 10px;
   }
   #side-pane {
     width: 90%;
@@ -109,5 +114,8 @@ ul.filters li {
 @media only screen and (min-width: 1024px) {
   #left-hamburger {
     display: none;
+  }
+  #legend.map-overlay div {
+    margin-bottom: 10px;
   }
 }


### PR DESCRIPTION
This PR updates the legend styles to provide more room between elements on both desktop and mobile as well as eliminates a conflict between the legend and the Mapbox attribution elements on mobile.

`master`:

Mobile:

<img width="375" alt="image" src="https://user-images.githubusercontent.com/1739551/83577960-2d2ea680-a4fb-11ea-9f33-1b1b67d7ef31.png">


Desktop:

<img width="1196" alt="image" src="https://user-images.githubusercontent.com/1739551/83577937-2142e480-a4fb-11ea-8b73-e3acf2baf786.png">


`legend-styles` 

Mobile:

<img width="374" alt="image" src="https://user-images.githubusercontent.com/1739551/83577863-f48ecd00-a4fa-11ea-9ecd-b93e1becd6f8.png">

Desktop:
<img width="1201" alt="image" src="https://user-images.githubusercontent.com/1739551/83577905-11c39b80-a4fb-11ea-9dcb-32656411cd72.png">
